### PR TITLE
Fix typo in the identify API endpoint

### DIFF
--- a/src/Siro/Klaviyo/KlaviyoEvent.php
+++ b/src/Siro/Klaviyo/KlaviyoEvent.php
@@ -100,7 +100,7 @@ class KlaviyoEvent extends ApiBase
         ];
 
         $response = $this->client->get(
-            '/api/indentify',
+            '/api/identify',
             [
             'query' => [
                 'data' => base64_encode(json_encode($data))
@@ -132,7 +132,7 @@ class KlaviyoEvent extends ApiBase
         ];
 
         return $this->client->getAsync(
-            '/api/indentify',
+            '/api/identify',
             [
             'query' => [
                 'data' => base64_encode(json_encode($data))


### PR DESCRIPTION
This commit fixes a typo in the KlaviyoEvent::identify and KlaviyoEvent::identifyAsync API endpoint which breaks the identify functionality in its current state.