### PR TITLE
feat(profile): Add search method to allow searching for profiles base…

### DIFF
--- a/src/Siro/Klaviyo/KlaviyoProfile.php
+++ b/src/Siro/Klaviyo/KlaviyoProfile.php
@@ -39,7 +39,7 @@ class KlaviyoProfile extends ApiBase
         foreach ($properties as $property => $value) {
             $requestParams['form_params'][$property] = $value;
         }
-        
+
         $response = $this->client->put("/api/v1/person/{$personId}", $requestParams);
 
         return $this->sendResponseAsObject($response);
@@ -86,4 +86,24 @@ class KlaviyoProfile extends ApiBase
 
         return $this->sendResponseAsObject($response);
     }
+
+	/**
+	 * GET /api/v2/person/{{ PERSON_ID }}
+	 *
+	 * @param string $email
+	 * @param string $identifier - can be 'email', 'phone_number' or 'external_id'
+	 */
+	public function search( $email, $identifier = 'email' )
+	{
+		$response = $this->client->get( "/api/v2/people/search",
+			[
+				'query' => [
+					'api_key'   => $this->apiKey,
+					$identifier => $email
+				]
+			]
+		);
+
+		return $this->sendResponseAsObject( $response );
+	}
 }


### PR DESCRIPTION
Adds a method to the profiles client allowing us to search for a profile based on basic personal identifiers: email, phone_number or external_id.

This is critical if the site owner does not store the personal IDs already, as Klaviyo will be discontinuing the possibility to update personal identifiers through the identify API. This must be done from the profiles API in the future.